### PR TITLE
Update to support GLib 2.68

### DIFF
--- a/GLib-2.0.blacklist
+++ b/GLib-2.0.blacklist
@@ -1,3 +1,4 @@
 assertion_message_cmpnum
 String_autoptr
 g_iconv
+g_time_zone_new

--- a/GLib-2.0.sed
+++ b/GLib-2.0.sed
@@ -43,3 +43,5 @@ s|\(func getObjv(length: .*UnsafeMutablePointer<\)UnsafeMutablePointer<gchar>|\1
 s|\(func getStrv(length: .*UnsafeMutablePointer<\)UnsafeMutablePointer<gchar>|\1UnsafePointer<gchar>|
 s|\(func get.*Names.*\)UnsafeMutablePointer<UnsafeMutablePointer<gchar>|\1UnsafePointer<UnsafePointer<gchar>|
 s|\(func get.*Dirs.*\)UnsafeMutablePointer<UnsafeMutablePointer<gchar>|\1UnsafePointer<UnsafePointer<gchar>|
+s|\GStrv\s|\GStrv!|
+s|(\sidentifier:|(identifierOrUtc identifier:|

--- a/GLib-2.0.sed
+++ b/GLib-2.0.sed
@@ -44,4 +44,5 @@ s|\(func getStrv(length: .*UnsafeMutablePointer<\)UnsafeMutablePointer<gchar>|\1
 s|\(func get.*Names.*\)UnsafeMutablePointer<UnsafeMutablePointer<gchar>|\1UnsafePointer<UnsafePointer<gchar>|
 s|\(func get.*Dirs.*\)UnsafeMutablePointer<UnsafeMutablePointer<gchar>|\1UnsafePointer<UnsafePointer<gchar>|
 s|\GStrv\s|\GStrv!|
-s|(\sidentifier:|(identifierOrUtc identifier:|
+s|@available(\*, deprecated) @inlinable init( identifier: UnsafePointer<gchar>? = nil)|@available(\*, deprecated) @inlinable init(identifierOrUtc identifier: UnsafePointer<gchar>? = nil)|g
+s|@available(\*, deprecated) @inlinable public init( identifier: UnsafePointer<gchar>? = nil)|@available(\*, deprecated) @inlinable public init(identiferOrUtc identifier: UnsafePointer<gchar>? = nil)|g

--- a/Sources/CGLib/glib_bridging.h
+++ b/Sources/CGLib/glib_bridging.h
@@ -212,6 +212,9 @@ struct _GDtlsClientConnection {};
 struct _GDtlsConnection {};
 struct _GDtlsServerConnection {};
 
+struct _GTreeNode {};
+struct _GStrvBuilder {};
+
 #define GLIB_DISABLE_DEPRECATION_WARNINGS
 #define G_SETTINGS_ENABLE_BACKEND
 #include <unistd.h>
@@ -350,3 +353,5 @@ typedef GUriError GURIError;
 typedef GUriFlags GURIFlags;
 typedef GUriParamsFlags GURIParamsFlags;
 typedef GUriHideFlags GURIHideFlags;
+typedef struct _GTreeNode GTreeNode;
+typedef struct _GStrvBuilder GStrvBuilder;


### PR DESCRIPTION
This pull request features several changes to support GLib 2.68. This includes:

- Defined GTreeNode and GStrvBuilder
- Modified sed to give correct return signature for GStrvBuilder.end
- Fixed issues with duplicate initialisers for GTimeZone